### PR TITLE
Update iprobe-overflow.c

### DIFF
--- a/mpi/bugs/iprobe-overflow.c
+++ b/mpi/bugs/iprobe-overflow.c
@@ -6,9 +6,17 @@ int main(int argc, char* argv[])
 {
     MPI_Init(&argc, &argv);
 
+/*
+*   Icc threw a diagnostic when i declared in for().
+*/
+    long i;
     double t0 = MPI_Wtime();
 
-    for (long i=0; LONG_MAX; i++) {
+/*
+*   Set limit of for() to 3G since bug breaks after 2.14G.
+*/
+    
+    for (i=0; i <= 3000000000L; i++) {
         int flag = 0;
         MPI_Status status;
         int rc = MPI_Iprobe(MPI_ANY_SOURCE, MPI_ANY_TAG, MPI_COMM_WORLD, &flag, &status);


### PR DESCRIPTION
For loop would run forever even for values of the limit above 2.14G (LONG_MAX always true).  Set limit of 3G so loop would finish.