### PR TITLE
Adding in 5+ versions of OpenMP

### DIFF
--- a/docs/Preprocessor-Macros.md
+++ b/docs/Preprocessor-Macros.md
@@ -43,6 +43,9 @@ OpenMP|``_OPENMP = 201107``|OpenMP 3.1
 OpenMP|``_OPENMP = 201307``|OpenMP 4.0
 OpenMP|``_OPENMP = 201511``|OpenMP 4.5
 OpenMP|``_OPENMP = 201811``|OpenMP 5.0
+OpenMP|``_OPENMP = 202011``|OpenMP 5.1
+OpenMP|``_OPENMP = 202111``|OpenMP 5.2
+OpenMP|``_OPENMP = 202411``|OpenMP 6.0
 Cilk|`__cilk = 200`|Cilk++
 
 # Compilers


### PR DESCRIPTION
Cribbed from https://www.openmp.org/specifications/ this adds 5.1, 5.2 and 6.0 version to dates of spec release.